### PR TITLE
Fixing errors and warnings due to the astropy.vo.samp module moved to…

### DIFF
--- a/VESPA/VESPA.py
+++ b/VESPA/VESPA.py
@@ -28,8 +28,8 @@ from PyQt4 import QtGui
 import resources
 import threading
 
-from astropy.vo.samp import SAMPHubServer
-from astropy.vo.samp.hub import WebProfileDialog
+from astropy.samp import SAMPHubServer
+from astropy.samp.hub import WebProfileDialog
 
 from .scriptReceiver import scriptReceiver
 from .myHUB import *

--- a/VESPA/VOScriptReceiver.py
+++ b/VESPA/VOScriptReceiver.py
@@ -20,7 +20,7 @@
  *                                                                         *
  ***************************************************************************/
 """
-from astropy.vo.samp import SAMPIntegratedClient
+from astropy.samp import SAMPIntegratedClient
 from PyQt4.QtCore import QSettings, QTranslator, qVersion, QCoreApplication
 from PyQt4.QtGui import QAction, QIcon
 # Initialize Qt resources from file resources.py

--- a/VESPA/myHUB.py
+++ b/VESPA/myHUB.py
@@ -3,8 +3,8 @@ import resources
 import threading
 import sys
 import os
-from astropy.vo.samp import SAMPHubServer
-from astropy.vo.samp.hub import WebProfileDialog
+from astropy.samp import SAMPHubServer
+from astropy.samp.hub import WebProfileDialog
 import threading
 import time
 from qgis.core    import QgsProject, QgsMessageLog

--- a/VESPA/scriptReceiver.py
+++ b/VESPA/scriptReceiver.py
@@ -1,5 +1,5 @@
 from astropy.utils.data import download_file # fixes timeout bug
-from astropy.vo.samp import SAMPIntegratedClient
+from astropy.samp import SAMPIntegratedClient
 from astropy.table import Table
 import threading, time
 from qgis.core import *

--- a/polyToAladin/polyToAladin.py
+++ b/polyToAladin/polyToAladin.py
@@ -20,7 +20,7 @@
  *                                                                         *
  ***************************************************************************/
 """
-from astropy.vo.samp import SAMPIntegratedClient
+from astropy.samp import SAMPIntegratedClient
 
 from PyQt4.QtCore import QSettings, QTranslator, qVersion, QCoreApplication
 from PyQt4.QtGui import QAction, QIcon


### PR DESCRIPTION
QGIS 2.18.15, astropy 2.0.2: the error  'ImportError: No module named hub' is thrown when trying to load the VESPA plugin.